### PR TITLE
disable Kueue's waitForPodsReady feature

### DIFF
--- a/setup/mlbatch-subscription.yaml
+++ b/setup/mlbatch-subscription.yaml
@@ -158,7 +158,7 @@ data:
       burst: 100
     #pprofBindAddress: :8082
     waitForPodsReady:
-      enable: true
+      enable: false
       blockAdmission: false
     manageJobsWithoutQueueName: true
     #internalCertManagement:


### PR DESCRIPTION
Works around a configuration mismatch between Kueue and the AppWrapper reconciller in the CodeFlare operator.
