### PR TITLE
RHOAI 2.16.2 kueue metrics fix

### DIFF
--- a/setup.RHOAI-v2.16/mlbatch-subscription.yaml
+++ b/setup.RHOAI-v2.16/mlbatch-subscription.yaml
@@ -158,7 +158,7 @@ data:
     health:
       healthProbeBindAddress: :8081
     metrics:
-      bindAddress: :8080
+      bindAddress: :8443
       enableClusterQueueResources: true
     webhook:
       port: 9443

--- a/setup.RHOAI-v2.16/mlbatch-upgrade-configmaps.yaml
+++ b/setup.RHOAI-v2.16/mlbatch-upgrade-configmaps.yaml
@@ -46,7 +46,7 @@ data:
     health:
       healthProbeBindAddress: :8081
     metrics:
-      bindAddress: :8080
+      bindAddress: :8443
       enableClusterQueueResources: true
     webhook:
       port: 9443


### PR DESCRIPTION
The kueue metrics service changed from port 8080
to port 8443; adjust the mlbatch kueue configuration accordingly.
