### PR TITLE
fix: overwritten envFrom

### DIFF
--- a/tools/pytorchjob-generator/chart/templates/_helpers.tpl
+++ b/tools/pytorchjob-generator/chart/templates/_helpers.tpl
@@ -76,10 +76,17 @@ resources:
 
 
 {{- define "mlbatch.env" }}
+{{- $envFromList := list }}
+{{- if .Values.envFrom }}
+  {{- $envFromList = .Values.envFrom }}
+{{- end }}
 {{- if .Values.ncclGdrEnvConfigMap }}
+  {{- $configMapRef := dict "configMapRef" (dict "name" .Values.ncclGdrEnvConfigMap) }}
+  {{- $envFromList = append $envFromList $configMapRef }}
+{{- end }}
+{{- if $envFromList }}
 envFrom:
-  - configMapRef:
-      name: {{ .Values.ncclGdrEnvConfigMap }}
+{{- toYaml $envFromList | nindent 2 }}
 {{- end }}
 {{- if or .Values.environmentVariables .Values.sshGitCloneConfig .Values.mountNVMe .Values.topologyFileConfigMap ( eq .Values.schedulerName "sakkara" ) }}
 env:

--- a/tools/pytorchjob-generator/chart/templates/appwrapper.yaml
+++ b/tools/pytorchjob-generator/chart/templates/appwrapper.yaml
@@ -116,10 +116,6 @@ spec:
                                       {{- include "mlbatch.volumes" . | indent 38 }}
                                       containers:
                                           - name: pytorch
-                                            {{- if .Values.envFrom }}
-                                            envFrom:
-                                            {{- toYaml .Values.envFrom | nindent 46 }}
-                                            {{- end }}
                                             image: {{ required "Please specify a 'containerImage' in the user file" .Values.containerImage }}
                                             imagePullPolicy: {{ .Values.imagePullPolicy | default "IfNotPresent" }}
                                             {{- include "mlbatch.securityContext" . | indent 44 }}
@@ -143,10 +139,6 @@ spec:
                                       {{- include "mlbatch.volumes" . | indent 38 }}
                                       containers:
                                           - name: pytorch
-                                            {{- if .Values.envFrom }}
-                                            envFrom:
-                                            {{- toYaml .Values.envFrom | nindent 46 }}
-                                            {{- end }}
                                             image: {{ required "Please specify a 'containerImage' in the user file" .Values.containerImage }}
                                             imagePullPolicy: {{ .Values.imagePullPolicy | default "IfNotPresent" }}
                                             {{- include "mlbatch.securityContext" . | indent 44 }}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

This PR fixes an issue I introduced in #192 which I missed as it wasn't an issue in my testing environment.

#192 gives the user the option to specify an `envFrom` field. The problem is that if the user [also provides a ](https://github.com/garrett361/mlbatch/blob/4b72d6b010df18a3430123045f1270ca93cb3ff4/tools/pytorchjob-generator/chart/templates/_helpers.tpl?plain=1#L79-L83) `ncclGdrEnvConfigMap` value, then this results in another `envFrom` field being created which overwrites the first. I wasn't providing `ncclGdrEnvConfigMap` in the env I tested in, so I missed this fact. 

This PR merges any provided envFrom fields. 

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

Now tested in an environment where I also specify `ncclGdrEnvConfigMap`

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->